### PR TITLE
Fix markdown links

### DIFF
--- a/converter.py
+++ b/converter.py
@@ -213,7 +213,8 @@ def process_page_content(body):
     return converted_text
 
 def adjust_content_links(pages):
-    renderer = MdRenderer(pages_by_node_id)
+    renderer = MdRenderer()
+    renderer.init(pages_by_node_id)
     transform_links = mistune.Markdown(renderer=renderer, inline=WikiLinkInlineLexer(renderer))
     for page in pages:
             page.content = transform_links(page.content)

--- a/converter.py
+++ b/converter.py
@@ -42,6 +42,7 @@ def convert_atrium_db_to_xar():
         if elem[0] not in productive_page_by_nid:
             to_migrate.append(elem)
             productive_page_by_nid[elem[0]] = elem
+            assert(type(elem[0]) is int)
 
     num_cores = multiprocessing.cpu_count()
     migrated = Parallel(n_jobs=num_cores)(delayed(convert_single_entry)(elem) for elem in to_migrate)

--- a/converter.py
+++ b/converter.py
@@ -29,7 +29,7 @@ def convert_atrium_db_to_xar():
             inner join openatrium_node_revisions as r \
             on n.nid = r.nid \
             where n.type = \"book\" \
-            order by n.nid desc, r.vid desc")
+            order by n.nid desc, r.vid desc limit 100")
 
     migrated = []
     # since the syntax for xwiki documents with history is not particularly beautiful, we skip
@@ -213,7 +213,8 @@ def process_page_content(body):
     return converted_text
 
 def adjust_content_links(pages):
-    transform_links = mistune.Markdown(MdRenderer(pages_by_node_id), inline=WikiLinkInlineLexer())
+    renderer = MdRenderer(pages_by_node_id)
+    transform_links = mistune.Markdown(renderer=renderer, inline=WikiLinkInlineLexer())
     for page in pages:
             page.content = transform_links(page.content)
 

--- a/converter.py
+++ b/converter.py
@@ -29,7 +29,7 @@ def convert_atrium_db_to_xar():
             inner join openatrium_node_revisions as r \
             on n.nid = r.nid \
             where n.type = \"book\" \
-            order by n.nid desc, r.vid desc limit 100")
+            order by n.nid desc, r.vid desc")
 
     migrated = []
     # since the syntax for xwiki documents with history is not particularly beautiful, we skip
@@ -214,7 +214,7 @@ def process_page_content(body):
 
 def adjust_content_links(pages):
     renderer = MdRenderer(pages_by_node_id)
-    transform_links = mistune.Markdown(renderer=renderer, inline=WikiLinkInlineLexer())
+    transform_links = mistune.Markdown(renderer=renderer, inline=WikiLinkInlineLexer(renderer))
     for page in pages:
             page.content = transform_links(page.content)
 

--- a/converter.py
+++ b/converter.py
@@ -214,11 +214,11 @@ def process_page_content(body):
     return converted_text
 
 def adjust_content_links(pages):
-    renderer = MdRenderer()
-    renderer.init(pages_by_node_id)
-    transform_links = mistune.Markdown(renderer=renderer, inline=WikiLinkInlineLexer(renderer))
     for page in pages:
-            page.content = transform_links(page.content)
+        renderer = MdRenderer()
+        renderer.init(page, pages_by_node_id)
+        transform_links = mistune.Markdown(renderer=renderer, inline=WikiLinkInlineLexer(renderer))
+        page.content = transform_links(page.content)
 
 def create_project_file(pages):
     root = Element("package")

--- a/mdrenderer.py
+++ b/mdrenderer.py
@@ -16,8 +16,8 @@ import re
 
 class MdRenderer(Renderer):
 
-  def init(self, pages):
-
+  def init(self, current_page, pages):
+    self.current_page = current_page
     self.pages = pages
     self.is_atrium_link = re.compile(r'https://atrium\.studieren-ohne-grenzen\.org/[\S]+?/node/([\S]+)')
 
@@ -86,16 +86,16 @@ class MdRenderer(Renderer):
   def autolink(self, link, is_email=False):
     m = self.is_atrium_link.match(link)
     if m and m.group(1) in self.pages:
-      linked_page = self.pages[m.group(1)][0]
-      return self.wiki_link('doc:'+linked_page.build_prefixed_path(), linked_page.title)
+      linked_page = self.pages[int(m.group(1))][0]
+      return self.wiki_link('doc:'+linked_page.build_relative_path(self.prefixed_page.build_prefixed_path()), linked_page.title)
     else:
       return '<' + link + '>'
 
   def link(self, link, title, text, image=False):
     m = self.is_atrium_link.match(link)
     if m and not image and m.group(1) in self.pages:
-      linked_page = self.pages[m.group(1)][0]
-      return self.wiki_link('doc:'+linked_page.build_prefixed_path(), text)
+      linked_page = self.pages[int(m.group(1))][0]
+      return self.wiki_link('doc:'+linked_page.build_relative_path(self.build_prefixed_path()), text)
     else:
       r = (image and '!' or '') + '[' + text + '](' + link + ')'
     if title:

--- a/mdrenderer.py
+++ b/mdrenderer.py
@@ -87,7 +87,7 @@ class MdRenderer(Renderer):
     m = self.is_atrium_link.match(link)
     if m and m.group(1) in self.pages:
       linked_page = self.pages[int(m.group(1))][0]
-      return self.wiki_link('doc:'+linked_page.build_relative_path(self.prefixed_page.build_prefixed_path()), linked_page.title)
+      return self.wiki_link('doc:'+linked_page.build_relative_path(self.current_page.build_prefixed_path()), linked_page.title)
     else:
       return '<' + link + '>'
 
@@ -95,7 +95,7 @@ class MdRenderer(Renderer):
     m = self.is_atrium_link.match(link)
     if m and not image and m.group(1) in self.pages:
       linked_page = self.pages[int(m.group(1))][0]
-      return self.wiki_link('doc:'+linked_page.build_relative_path(self.build_prefixed_path()), text)
+      return self.wiki_link('doc:'+linked_page.build_relative_path(self.current_page.build_prefixed_path()), text)
     else:
       r = (image and '!' or '') + '[' + text + '](' + link + ')'
     if title:

--- a/mdrenderer.py
+++ b/mdrenderer.py
@@ -83,7 +83,7 @@ class MdRenderer(Renderer):
 
   def autolink(self, link, is_email=False):
     m = self.is_atrium_link.match(link)
-    if m
+    if m:
       linked_page = self.pages[m.group(1)][0]
       return self.wiki_link('doc:'+linked_page.build_prefixed_path(), linked_page.title)
     else:
@@ -91,11 +91,11 @@ class MdRenderer(Renderer):
 
   def link(self, link, title, text, image=False):
     m = self.is_atrium_link.match(link)
-    if m and not image
+    if m and not image:
       linked_page = self.pages[m.group(1)][0]
       return self.wiki_link('doc:'+linked_page.build_prefixed_path(), text)
     else:
-    r = (image and '!' or '') + '[' + text + '](' + link + ')'
+      r = (image and '!' or '') + '[' + text + '](' + link + ')'
     if title:
       r += '"' + title + '"'
     return r

--- a/mdrenderer.py
+++ b/mdrenderer.py
@@ -12,11 +12,12 @@
 """
 
 from mistune import Renderer
+import re
 
 class MdRenderer(Renderer):
 
   def __init__(self, pages):
-    self.pages
+    self.pages = pages
     self.is_atrium_link = re.compile(r'https://atrium\.studieren-ohne-grenzen\.org/[\S]+?/node/([\S]+)')
 
   def get_block(text):

--- a/mdrenderer.py
+++ b/mdrenderer.py
@@ -16,7 +16,8 @@ import re
 
 class MdRenderer(Renderer):
 
-  def __init__(self, pages):
+  def init(self, pages):
+
     self.pages = pages
     self.is_atrium_link = re.compile(r'https://atrium\.studieren-ohne-grenzen\.org/[\S]+?/node/([\S]+)')
 

--- a/mdrenderer.py
+++ b/mdrenderer.py
@@ -1,0 +1,204 @@
+# coding: utf-8
+
+"""
+    Markdown renderer
+    ~~~~~~~~~~~~~~~~~
+
+    This class renders parsed markdown back to markdown.
+    It is useful for automatic modifications of the md contents.
+
+    :copyright: (c) 2015 by Jaroslav Kysela
+    :licence: WTFPL 2
+"""
+
+from mistune import Renderer
+
+class MdRenderer(Renderer):
+
+  def __init__(self, pages):
+    self.pages
+    self.is_atrium_link = re.compile(r'https://atrium\.studieren-ohne-grenzen\.org/[\S]+?/node/([\S]+)')
+
+  def get_block(text):
+    type = text[0]
+    p = text.find(':')
+    if p <= 0:
+      return ('', '', '')
+    l = int(text[1:p])
+    t = text[p+1:p+1+l]
+    return (text[p+1+l:], type, t)
+
+  def newline(self):
+    return '\n'
+
+  def text(self, text):
+    return text
+
+  def linebreak(self):
+    return '\n'
+
+  def hrule(self):
+    return '---\n'
+
+  def header(self, text, level, raw=None):
+    return '#'*(level+1) + text + '\n\n'
+
+  def paragraph(self, text):
+    return text + '\n\n'
+
+  def list(self, text, ordered=True):
+    r = ''
+    while text:
+      text, type, t = MdRenderer.get_block(text)
+      if type == 'l':
+        r += (ordered and ('# ' + t) or ('* ' + t)) + '\n'
+    return r
+
+  def list_item(self, text):
+    return 'l' + str(len(text)) + ':' + text
+
+  def block_code(self, code, lang=None):
+    return '```\n' + code + '\n```\n'
+
+  def block_quote(self, text):
+    r = ''
+    for line in text.splitlines():
+      r += (line and '> ' or '') + line + '\n'
+    return r
+
+  def _emphasis(self, text, pref):
+    return pref + text + pref + ' '
+
+  def emphasis(self, text):
+    return self._emphasis(text, '_')
+
+  def double_emphasis(self, text):
+    return self._emphasis(text, '__')
+
+  def strikethrough(self, text):
+    return self._emphasis(text, '~~')
+
+  def codespan(self, text):
+    return '`' + text + '`'
+
+  def autolink(self, link, is_email=False):
+    m = self.is_atrium_link.match(link)
+    if m
+      linked_page = self.pages[m.group(1)][0]
+      return self.wiki_link('doc:'+linked_page.build_prefixed_path(), linked_page.title)
+    else:
+      return '<' + link + '>'
+
+  def link(self, link, title, text, image=False):
+    m = self.is_atrium_link.match(link)
+    if m and not image
+      linked_page = self.pages[m.group(1)][0]
+      return self.wiki_link('doc:'+linked_page.build_prefixed_path(), text)
+    else:
+    r = (image and '!' or '') + '[' + text + '](' + link + ')'
+    if title:
+      r += '"' + title + '"'
+    return r
+
+  def wiki_link(self, link, text):
+    return '[[%s|%s]]' % (text, link)
+
+  def image(self, src, title, text):
+    self.link(src, title, text, image=True)
+
+  def table(self, header, body):
+    hrows = []
+    while header:
+      header, type, t = MdRenderer.get_block(header)
+      if type == 'r':
+        flags = {}
+        cols = []
+        while t:
+          t, type2, t2 = MdRenderer.get_block(t)
+          if type2 == 'f':
+            fl, v = t2.split('=')
+            flags[fl] = v
+          elif type2 == 'c':
+            cols.append(type('',(object,),{'flags':flags,'text':t2})())
+        hrows.append(cols)
+    brows = []
+    while body:
+      body, type, t = MdRenderer.get_block(body)
+      if type == 'r':
+        flags = {}
+        cols = []
+        while t:
+          t, type2, t2 = MdRenderer.get_block(t)
+          if type2 == 'f':
+            fl, v = t2.split('=')
+            flags[fl] = v
+          elif type2 == 'c':
+            cols.append(type('',(object,),{'flags':flags,'text':t2})())
+        brows.append(cols)
+    colscount = 0
+    colmax = [0] * 100
+    align = [''] * 100
+    for row in hrows + brows:
+      colscount = max(len(row), colscount)
+      i = 0
+      for col in row:
+        colmax[i] = max(len(col.text), colmax[i])
+        if 'align' in col.flags:
+          align[i] = col.flags['align'][0]
+        i += 1
+    r = ''
+    for row in hrows:
+      i = 0
+      for col in row:
+        if i > 0:
+          r += ' | '
+        r += col.text.ljust(colmax[i])
+        i += 1
+      r += '\n'
+    for i in range(colscount):
+      if i > 0:
+        r += ' | '
+      if align[i] == 'c':
+        r += ':' + '-'.ljust(colmax[i]-2, '-') + ':'
+      elif align[i] == 'l':
+        r += ':' + '-'.ljust(colmax[i]-1, '-')
+      elif align[i] == 'r':
+        r +=  '-'.ljust(colmax[i]-1, '-') + ':'
+      else:
+        r += '-'.ljust(colmax[i], '-')
+    r += '\n'
+    for row in brows:
+      i = 0
+      for col in row:
+        if i > 0:
+          r += ' | '
+        r += col.text.ljust(colmax[i])
+        i += 1
+      r += '\n'
+    return r
+
+  def table_row(self, content):
+    return 'r' + str(len(content)) + ':' + content
+
+  def table_cell(self, content, **flags):
+    content = content.replace('\n', ' ')
+    r = ''
+    for fl in flags:
+      v = flags[fl]
+      if type(v) == type(True):
+        v = v and 1 or 0
+      v = str(v) and str(v) or ''
+      r += 'f' + str(len(fl) + 1 + len(v)) + ':' + fl + '=' + v
+    return r + 'c' + str(len(content)) + ':' + content
+
+  def footnote_ref(self, key, index):
+    return '[^' + str(index) + ']'
+
+  def footnote_item(self, key, text):
+    r = '[^' + str(index) + ']:\n'
+    for l in text.split('\n'):
+      r += '  ' + l.lstrip().rstrip() + '\n'
+    return r
+
+  def footnotes(self, text):
+    return text

--- a/mdrenderer.py
+++ b/mdrenderer.py
@@ -85,7 +85,7 @@ class MdRenderer(Renderer):
 
   def autolink(self, link, is_email=False):
     m = self.is_atrium_link.match(link)
-    if m:
+    if m and m.group(1) in self.pages:
       linked_page = self.pages[m.group(1)][0]
       return self.wiki_link('doc:'+linked_page.build_prefixed_path(), linked_page.title)
     else:
@@ -93,7 +93,7 @@ class MdRenderer(Renderer):
 
   def link(self, link, title, text, image=False):
     m = self.is_atrium_link.match(link)
-    if m and not image:
+    if m and not image and m.group(1) in self.pages:
       linked_page = self.pages[m.group(1)][0]
       return self.wiki_link('doc:'+linked_page.build_prefixed_path(), text)
     else:

--- a/mdrenderer.py
+++ b/mdrenderer.py
@@ -98,13 +98,13 @@ class MdRenderer(Renderer):
   def autolink(self, link, is_email=False):
     linked_page = self.get_atrium_page(link) 
     if linked_page != False:
-        return self.wiki_link('doc:'+linked_page.build_prefixed_path(), linked_page.title)
+        return self.wiki_link('doc:'+linked_page.build_prefixed_path()+'.WebHome', linked_page.title)
     return '<' + link + '>'
 
   def link(self, link, title, text, image=False):
     linked_page = self.get_atrium_page(link) 
     if not image and linked_page != False:
-        return self.wiki_link('doc:'+linked_page.build_prefixed_path(), text)
+        return self.wiki_link('doc:'+linked_page.build_prefixed_path()+'.WebHome', text)
     r = (image and '!' or '') + '[' + text + '](' + link + ')'
     if title:
       r += '"' + title + '"'

--- a/mdrenderer.py
+++ b/mdrenderer.py
@@ -43,7 +43,7 @@ class MdRenderer(Renderer):
     return '---\n'
 
   def header(self, text, level, raw=None):
-    return '#'*(level+1) + text + '\n\n'
+    return '#'*(level+1) + ' ' + text + '\n\n'
 
   def paragraph(self, text):
     return text + '\n\n'

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ ply==3.11
 pypandoc==1.4
 six==1.11.0
 tomd==0.1.3
+mistune==0.8.3

--- a/wikilink_lexer.py
+++ b/wikilink_lexer.py
@@ -1,0 +1,18 @@
+class WikiLinkInlineLexer(InlineLexer):
+  def enable_wiki_link(self):
+    # add wiki_link rules
+    self.rules.wiki_link = re.compile(
+        r'\[\['                   # [[
+        r'([\s\S]+?\|[\s\S]+?)'   # Page 2|Page 2
+        r'\]\](?!\])'             # ]]
+    )
+
+    # Add wiki_link parser to default rules
+    # you can insert it some place you like
+    # but place matters, maybe 3 is not good
+    self.default_rules.insert(3, 'wiki_link')
+
+  def output_wiki_link(self, m):
+    text = m.group(1)
+    alt, link = text.split('|')
+    return self.renderer.wiki_link(alt, link)

--- a/wikilink_lexer.py
+++ b/wikilink_lexer.py
@@ -1,3 +1,5 @@
+from mistune import InlineLexer
+
 class WikiLinkInlineLexer(InlineLexer):
   def enable_wiki_link(self):
     # add wiki_link rules

--- a/xwiki.py
+++ b/xwiki.py
@@ -1,4 +1,5 @@
 from xml.etree.ElementTree import Element, SubElement, dump, tostring, ElementTree
+from os import path
 
 class XWikiFile(object):
 
@@ -21,6 +22,9 @@ class XWikiFile(object):
 
     def build_prefixed_path(self):
         return self.path_prefix + "." + self.build_path()
+
+    def build_relative_path(self, origin):
+        return path.relpath(self.build.prefixed_path().replace('.', path.sep), origin.replace('.', path.sep)).replace(path.sep, '.')
 
     def build_xml_content_file(self):
         root = Element("xwikidoc")

--- a/xwiki.py
+++ b/xwiki.py
@@ -18,13 +18,10 @@ class XWikiFile(object):
         if self.parent_node is None:
             return self.qualifier
 
-        return self.parent_node.build_path() + "." + self.qualifier
+        return self.parent_node.build_path() + "." + self.qualifier + '.WebHome'
 
     def build_prefixed_path(self):
         return self.path_prefix + "." + self.build_path()
-
-    def build_relative_path(self, origin):
-        return path.relpath(self.build.prefixed_path().replace('.', path.sep), origin.replace('.', path.sep)).replace(path.sep, '.')
 
     def build_xml_content_file(self):
         root = Element("xwikidoc")

--- a/xwiki.py
+++ b/xwiki.py
@@ -18,7 +18,7 @@ class XWikiFile(object):
         if self.parent_node is None:
             return self.qualifier
 
-        return self.parent_node.build_path() + "." + self.qualifier + '.WebHome'
+        return self.parent_node.build_path() + "." + self.qualifier
 
     def build_prefixed_path(self):
         return self.path_prefix + "." + self.build_path()
@@ -35,7 +35,7 @@ class XWikiFile(object):
         SubElement(root, "translation").text = "0"
         SubElement(root, "creator").text = "XWiki.OAMigrator"
         SubElement(root, "creationDate").text = ""
-        SubElement(root, "parent").text = (self.parent_node.build_prefixed_path() if self.parent_node else self.path_prefix) + ".WebHome"
+        SubElement(root, "parent").text = (self.parent_node.build_prefixed_path() if self.parent_node else self.path_prefix) + '.WebHome'
         SubElement(root, "author").text = self.get_xwiki_author()
         SubElement(root, "contentAuthor").text = self.get_xwiki_author()
         SubElement(root, "date").text = ""


### PR DESCRIPTION
Ich habe mal einen pull request gemacht, da höchstwarscheinlich noch commits dazu kommen -- es ist ungetestet (TM)

Die Idee ist, einen markdown parser drüberlaufen zu lassen und den parse tree wieder in markdown zu serialisieren, wobei ich im renderer einen filter eingebaut habe, der atrium links in wiki links umbiegt.