### PR TITLE
Add script to fix markdown table formatting

### DIFF
--- a/md_format_tables.py
+++ b/md_format_tables.py
@@ -1,0 +1,31 @@
+#!/usr/bin/python
+
+# files to be replaced with REST-Requests
+file1 = open('table.txt')
+md_input = file1.read()
+file2 = open('table2.txt','w')
+
+#iterate over lines
+lines = md_input.split('\n')
+md_output = ''
+
+i=0
+
+while (i<len(lines)):
+	
+	#append all following lines of a table row
+	if (lines[i][:1]=='|'):
+		while(i<len(lines) and lines[i][-1:]!='|'):
+			md_output += lines[i] + ' '
+			i+=1
+		#last line ends with |
+		md_output += lines[i]
+
+	#otherwise this is not a table
+	else:
+		md_output += lines[i]
+	
+	md_output += '\n'
+	i+=1
+
+file2.write(md_output)

--- a/md_format_tables.py
+++ b/md_format_tables.py
@@ -1,31 +1,39 @@
 #!/usr/bin/python
 
-# files to be replaced with REST-Requests
-file1 = open('table.txt')
-md_input = file1.read()
-file2 = open('table2.txt','w')
-
-#iterate over lines
-lines = md_input.split('\n')
-md_output = ''
-
-i=0
-
-while (i<len(lines)):
+def md_convert_tables(md_input):
 	
-	#append all following lines of a table row
-	if (lines[i][:1]=='|'):
-		while(i<len(lines) and lines[i][-1:]!='|'):
-			md_output += lines[i] + ' '
-			i+=1
-		#last line ends with |
-		md_output += lines[i]
+	#iterate over lines
+	lines = md_input.split('\n')
+	md_output = ''
 
-	#otherwise this is not a table
-	else:
-		md_output += lines[i]
-	
-	md_output += '\n'
-	i+=1
+	i=0
 
-file2.write(md_output)
+	while (i<len(lines)):
+		
+		#tables start with |
+		if (lines[i][:1]=='|'):
+
+			# append all lines belonging to the same table row
+			while(i<len(lines) and lines[i][-1:]!='|'):
+				md_output += lines[i] + ' '
+				i+=1
+			#last line ends with |
+			md_output += lines[i]
+
+		#otherwise this is not a table
+		else:
+			md_output += lines[i]
+		
+		md_output += '\n'
+		i+=1
+
+	return md_output
+
+
+def md_files_convert():
+	input_file  = open('table.txt')
+	output_file = open('table2.txt','w')
+	output_file.write(md_convert_tables(input_file.read()))
+
+
+md_files_convert()


### PR DESCRIPTION
A Python script that takes XWiki-Markdown 1.2 code and corrects formatting issues within tables by clearing out line breaks that harm the table layout